### PR TITLE
fixed: when url from another image proxy is used params not extracted…

### DIFF
--- a/src/Classes/Response.php
+++ b/src/Classes/Response.php
@@ -22,14 +22,14 @@ class Response
     }
 
 	private function auth(){
-		$authenticator = new Auth($_REQUEST);
+		$authenticator = new Auth($GLOBALS);
 		if(!$authenticator->is_authenticated()){
 			$this->render('Error', 'Auth Error: Check your credentials');
 		}
 	}
 
 	private function set_image(){
-		$request = new Request($_REQUEST['source_url']);
+		$request = new Request($GLOBALS['source_url']);
 		if(count($request->errors) > 0){
 			return $this->render('Error',json_encode($request->errors));
 		}
@@ -37,7 +37,7 @@ class Response
 	}
 
     private function manipulate_image(){
-    	$params= isset($_REQUEST['params']) ? $_REQUEST['params'] : '';
+    	$params= isset($GLOBALS['params']) ? $GLOBALS['params'] : '';
         $manipulator = new Manipulator($this->source_image,$params);
 	    if(count($manipulator->errors) > 0){
 		    return $this->render('Error',json_encode($manipulator->errors));

--- a/src/index.php
+++ b/src/index.php
@@ -3,11 +3,20 @@ require 'config.php';
 require 'Classes/Autoloader.php';
 require '../vendor/autoload.php';
 
-if(!isset($_REQUEST['params']) && !isset($_REQUEST['source_url'])){
+$url_parts = explode("/http",$_SERVER["REQUEST_URI"]);
+
+if(sizeof($url_parts) < 2){
 	die('');
 }
 
-if(!preg_match('/^http/',$_REQUEST['source_url']) ){
+$params_parts = explode('/', $url_parts[0]);
+
+$GLOBALS['params'] = $params_parts[sizeof($params_parts)-1];
+$GLOBALS['source_url'] = "http".$url_parts[1];
+
+if(!isset($GLOBALS['params']) && !isset($GLOBALS['source_url'])){
 	die('');
 }
+
 $response = new Response();
+


### PR DESCRIPTION
… correctly, for example:  "https://thumbnails.trvl-media.com/3ZXoqEexx2_o7rxqFmT-N8S_gCs=/773x530/smart/filters:quality(60)/images.trvl-media.com/hotels/20000000/19300000/19299100/19299002/c9378282_z.jpg"